### PR TITLE
Added EventID1 collumn to the removal

### DIFF
--- a/SEBrowser/Scripts/TSX/Components/EventSearch/EventSearchList.tsx
+++ b/SEBrowser/Scripts/TSX/Components/EventSearch/EventSearchList.tsx
@@ -73,7 +73,7 @@ export default function EventSearchList(props: IProps) {
         if (data.length == 0)
             return;
 
-        flds = Object.keys(data[0]).filter(item => item != "Time" && item != "DisturbanceID" && item != "EventID" && item != 'MagDurDuration' && item != 'MagDurMagnitude').sort();
+        flds = Object.keys(data[0]).filter(item => item != "Time" && item != "DisturbanceID" && item != "EventID" && item != "EventID1" && item != 'MagDurDuration' && item != 'MagDurMagnitude').sort();
 
         
         if (flds.length != cols.length)


### PR DESCRIPTION
`EventID` should only be used for JOIN in the Server and not show up in the Table. Due to duplicate collumns `EventID1` showed up as a collumn to the user. Added logic to remove that collumn.