### PR TITLE
Fix Navigation

### DIFF
--- a/SEBrowser/package.json
+++ b/SEBrowser/package.json
@@ -21,7 +21,7 @@
     "@gpa-gemstone/gpa-symbols": "0.0.25",
     "@gpa-gemstone/react-forms": "1.1.36",
     "@gpa-gemstone/react-graph": "1.0.27",
-    "@gpa-gemstone/react-interactive": "1.0.78",
+    "@gpa-gemstone/react-interactive": "1.0.79",
     "@gpa-gemstone/react-table": "1.2.22",
     "@reduxjs/toolkit": "1.8.3",
     "@types/d3": "7.1.0",


### PR DESCRIPTION
This updates `gpa-gemstone\react-interactive` to add the sidebar links back in. There was a bug in the package