### PR TITLE
1343 result initial sort

### DIFF
--- a/SEBrowser/Scripts/TSX/Components/EventSearch/EventSearchList.tsx
+++ b/SEBrowser/Scripts/TSX/Components/EventSearch/EventSearchList.tsx
@@ -194,7 +194,7 @@ export default function EventSearchList(props: IProps) {
             {status == 'loading' ? null :
                 data.length == numberResults ?
                     <div style={{ padding: 10, backgroundColor: '#458EFF', color: 'white' }} ref={count}>
-                        Only the first {data.length} results are shown - please narrow your search or increase the number of results
+                        Only the first {data.length} chronological results are shown - please narrow your search or increase the number of results in the application settings
                     </div> :
                     <div style={{ padding: 10, backgroundColor: '#458EFF', color: 'white' }} ref={count}>
                         {data.length} results

--- a/SEBrowser/Scripts/TSX/Components/EventSearch/EventSearchList.tsx
+++ b/SEBrowser/Scripts/TSX/Components/EventSearch/EventSearchList.tsx
@@ -46,9 +46,7 @@ export default function EventSearchList(props: IProps) {
     const ref = React.useRef();
     const closureHandler = React.useRef<((o: boolean) => void)>(() => { })
     const count = React.useRef(null);
-
     const dispatch = useAppDispatch();
-
     const status = useAppSelector(SelectEventSearchsStatus);
     const sortField = useAppSelector(SelectEventSearchsSortField);
     const ascending = useAppSelector(SelectEventSearchsAscending);
@@ -80,7 +78,6 @@ export default function EventSearchList(props: IProps) {
 
         flds = Object.keys(data[0]).filter(item => item != "Time" && item != "DisturbanceID" && item != "EventID" && item != "EventID1" && item != 'MagDurDuration' && item != 'MagDurMagnitude').sort();
 
-
         if (flds.length != cols.length)
             setCols(flds.map(item => ({
                 field: item, key: item, label: item, content: (item, key, fld, style) => ProcessWhitespace(item[fld]) })))
@@ -90,7 +87,6 @@ export default function EventSearchList(props: IProps) {
     React.useLayoutEffect(() => {
         setHCounter(count?.current?.offsetHeight ?? 0)
     });
-
 
     function closeSettings(open: boolean) {
         closureHandler.current(open);
@@ -142,7 +138,6 @@ export default function EventSearchList(props: IProps) {
 
         if(scrollTop <= sectionIndex * tableSectionHeight || scrollTop >= (sectionIndex + 1) * tableSectionHeight - tableSectionHeight/2)
             $(ReactDOM.findDOMNode(ref.current)).find('tbody').scrollTop(sectionIndex * tableSectionHeight);
-
     }
 
     function ProcessWhitespace(txt: string | number): React.ReactNode {
@@ -194,7 +189,7 @@ export default function EventSearchList(props: IProps) {
             {status == 'loading' ? null :
                 data.length == numberResults ?
                     <div style={{ padding: 10, backgroundColor: '#458EFF', color: 'white' }} ref={count}>
-                        Only the first {data.length} chronological results are shown - please narrow your search or increase the number of results in the application settings
+                        Only the first {data.length} chronological results are shown - please narrow your search or increase the number of results in the application settings.
                     </div> :
                     <div style={{ padding: 10, backgroundColor: '#458EFF', color: 'white' }} ref={count}>
                         {data.length} results

--- a/SEBrowser/Scripts/TSX/Components/EventSearch/EventSearchMagDur.tsx
+++ b/SEBrowser/Scripts/TSX/Components/EventSearch/EventSearchMagDur.tsx
@@ -38,18 +38,15 @@ interface IProps {
     EventID: number,
     SelectEvent: (id: number) => void,
 }
-const MagDurChart = (props: IProps) => {
 
+const MagDurChart = (props: IProps) => {
     const chart = React.useRef(null);
     const count = React.useRef(null);
     const empty = React.useCallback(() => { }, []);
-    
     const magDurStatus = useAppSelector(MagDurCurveSlice.Status);
     const magDurCurves = useAppSelector(MagDurCurveSlice.Data) as SEBrowser.MagDurCurve[];
- 
     const [currentCurve, setCurrentCurve] = React.useState<SEBrowser.MagDurCurve>(null)
     const numberResults = useAppSelector((state: Redux.StoreState) => SelectEventSearchSettings(state).NumberResults)
-
     const [width, setWidth] = React.useState<number>(0);
     const [x, setX] = React.useState<boolean>(false);
     const [hCounter, setHCounter] = React.useState<number>(0);
@@ -60,7 +57,6 @@ const MagDurChart = (props: IProps) => {
     const [selectedMag, setSelectedMag] = React.useState<number>(0);
     const [selectedDur, setSelectedDur] = React.useState<number>(0);
     const settings = useAppSelector(SelectEventSearchSettings);
-
     const selectedCurve = useAppSelector((state: Redux.StoreState) => SelectCharacteristicFilter(state).curveID);
     const showSelectedCurve = useAppSelector((state: Redux.StoreState) => SelectCharacteristicFilter(state).curveInside != SelectCharacteristicFilter(state).curveOutside);
 
@@ -212,7 +208,7 @@ const MagDurChart = (props: IProps) => {
             {status == 'loading' ? null :
                 data.length == numberResults ?
                     <div style={{ padding: 10, backgroundColor: '#458EFF', color: 'white' }} ref={count}>
-                        Only the first {data.length}  chronological results are shown - please narrow your search or increase the number of results in the application settings
+                        Only the first {data.length}  chronological results are shown - please narrow your search or increase the number of results in the application settings.
                     </div> :
                     <div style={{ padding: 10, backgroundColor: '#458EFF', color: 'white' }} ref={count}>
                         {data.length} results
@@ -241,7 +237,6 @@ const EventList = (props: IEventListProps) => {
         [props.Magnitude, props.Duration])
 
     const dispatch = useAppDispatch();
-
     const sortField = useAppSelector(SelectEventSearchsSortField);
     const ascending = useAppSelector(SelectEventSearchsAscending);
     const data = useAppSelector(dataFilter);
@@ -271,7 +266,6 @@ const EventList = (props: IEventListProps) => {
     function LoadColumns() {
         let c = [{ field: "Time", key: "Time", label: "Time", content: (item, key, fld, style) => ProcessWhitespace(item[fld]) }];
         const flds = Object.keys(data[0]).filter(item => item != "Time" && item != "DisturbanceID" && item != "EventID" && item != "EventID1" && item != 'MagDurDuration' && item != 'MagDurMagnitude').sort();
-
         let keys = [];
         const currentState = localStorage.getItem('SEbrowser.EventSearch.TableCols');
         if (currentState !== null)

--- a/SEBrowser/Scripts/TSX/Components/EventSearch/EventSearchMagDur.tsx
+++ b/SEBrowser/Scripts/TSX/Components/EventSearch/EventSearchMagDur.tsx
@@ -212,7 +212,7 @@ const MagDurChart = (props: IProps) => {
             {status == 'loading' ? null :
                 data.length == numberResults ?
                     <div style={{ padding: 10, backgroundColor: '#458EFF', color: 'white' }} ref={count}>
-                        Only the first {data.length} results are shown - please narrow your search or increase the number of results
+                        Only the first {data.length}  chronological results are shown - please narrow your search or increase the number of results in the application settings
                     </div> :
                     <div style={{ padding: 10, backgroundColor: '#458EFF', color: 'white' }} ref={count}>
                         {data.length} results

--- a/SEBrowser/Scripts/TSX/Components/EventSearch/EventSearchSlice.ts
+++ b/SEBrowser/Scripts/TSX/Components/EventSearch/EventSearchSlice.ts
@@ -29,12 +29,12 @@ import moment from 'moment';
 import queryString from 'querystring';
 import { AssetGroupSlice, AssetSlice, EventTypeSlice, LocationSlice, MeterSlice } from '../../Store';
 import { SystemCenter, OpenXDA } from '@gpa-gemstone/application-typings';
-import SEBrowserdService from '../../../TS/Services/SEBrowser';
 
 
-const momentDateTimeFormat = "MM/DD/YYYY HH:mm:ss.SSS";
+
+
 const momentDateFormat = "MM/DD/YYYY";
-const momentTimeFormat = "HH:mm:ss.SSS";
+
 
 let fetchHandle: JQuery.jqXHR<any> | null = null;
 
@@ -151,7 +151,7 @@ export const EventSearchsSlice = createSlice({
         Status: 'unitiated',
         Data: [],
         Error: null,
-        SortField: 'FileStartTime',
+        SortField: 'Time',
         Ascending: true,
         SearchText: '',
         EventCharacteristic: {

--- a/SEBrowser/Scripts/TSX/Components/EventSearch/EventSearchSlice.ts
+++ b/SEBrowser/Scripts/TSX/Components/EventSearch/EventSearchSlice.ts
@@ -30,11 +30,7 @@ import queryString from 'querystring';
 import { AssetGroupSlice, AssetSlice, EventTypeSlice, LocationSlice, MeterSlice } from '../../Store';
 import { SystemCenter, OpenXDA } from '@gpa-gemstone/application-typings';
 
-
-
-
 const momentDateFormat = "MM/DD/YYYY";
-
 
 let fetchHandle: JQuery.jqXHR<any> | null = null;
 
@@ -47,7 +43,6 @@ export const FetchEventSearches = createAsyncThunk('EventSearchs/FetchEventSearc
     const assetList = (getState() as any).EventSearch.SelectedAssets as SystemCenter.Types.DetailedAsset[];
     const locationList = (getState() as any).EventSearch.SelectedStations as SystemCenter.Types.DetailedLocation[];
     const groupList = (getState() as any).EventSearch.SelectedGroups as OpenXDA.Types.AssetGroup[];
-
     const settings = (getState() as Redux.StoreState).Settings.eventSearch;
 
     const filter = {


### PR DESCRIPTION
Ticket_1343 "Currently the sort column and order is not indicated on a new search. The arrow should be present to show the user how results are being sorted. The initial sort should be chronologically from oldest to newest." This was resolved by, In EventSearchSlice.ts, updateing initialState > SortField to sort by "Time" instead of "FIleStartTime". Removed some unused references. Updated the verbiage in the message at the bottom of the results table.