### PR TITLE
Updated Scripts to allow Branches

### DIFF
--- a/Scripts/UpdateDependencies.bat
+++ b/Scripts/UpdateDependencies.bat
@@ -83,9 +83,15 @@ IF NOT "%donotpush%" == "" GOTO Finish
 :PushChanges
 ECHO.
 ECHO Pushing changes to remote repository...
-"%git%" push
+SET remotebranch=master
+IF "%pushtoversionbranch%" == "true" SET remotebranch=ud-%version%
+"%git%" push origin HEAD:%remotebranch%
+
+:AfterPushChanges
 CD /D %pwd%
+IF EXIST "%afterpushscript%" CALL "%afterpushscript%" SystemCenter %remotebranch%
 
 :Finish
+CD /D %pwd%
 ECHO.
 ECHO Update complete


### PR DESCRIPTION
Updated `UpdateDependencies.bat` to allow pushing to a remote branch.
This will allow us to use the `SEB-UD.bat` script on `buildbot again