### PR TITLE
Fix for series who are not min/max/avg defaulting to avg properly

### DIFF
--- a/SEBrowser/Scripts/TSX/Components/TrendData/TrendPlot/TrendPlot.tsx
+++ b/SEBrowser/Scripts/TSX/Components/TrendData/TrendPlot/TrendPlot.tsx
@@ -268,10 +268,11 @@ const TrendPlot: React.FunctionComponent<IContainerProps> = (props: IContainerPr
                         }
                     };
                     channel.Series.forEach(series => {
+                        const defaultsUsed = props.LineDefaults?.[series.TypeName] ?? props.LineDefaults.Average;
                         settings.Settings[series.TypeName] = {
-                            Color: color[series.TypeName],
-                            Width: props.LineDefaults?.[series.TypeName].Default.Width,
-                            Type: props.LineDefaults?.[series.TypeName].Default.Type,
+                            Color: color?.[series.TypeName] ?? color.Average,
+                            Width: defaultsUsed.Default.Width,
+                            Type: defaultsUsed.Default.Type,
                             Axis: 'left',
                             Label: constructLabel(channel, series),
                             HasData: false


### PR DESCRIPTION
For [PQB-92](https://gridprotectionalliance.atlassian.net/browse/PQB-92)

Fix for channels with any series that aren't min/max/avg from breaking the graphs.

Easy channel to test with is demo -> dranetz -> I Demand All

